### PR TITLE
Define loose range for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "jest": "^20.0.4"
   },
   "peerDependencies": {
-    "rollup": "^0.45.2"
+    "rollup": ">=0.45.2"
   },
   "dependencies": {
     "safe-resolve": "^1.0.0"


### PR DESCRIPTION
Define a loose range for Rollup as a peerDependency so users are not locked in to a specific version

Fixes #1 