### PR TITLE
adds support for adding Node.js builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ export default {
     autoExternal({
       dependencies: true,
       peerDependencies: false,
+      builtins: false
     }),
   ],
 };
@@ -66,3 +67,10 @@ export default {
 #### `peerDependencies`
 
 `boolean`: defaults to `true`.
+
+#### `builtins`
+
+`boolean`|`string`: defaults to `false`. Pass `true` to add all Node.js builtin modules (in the running version) as externals. Specify a `string` value (e.g., `'6.0.0'`) to add all builtin modules for a *specific version* of Node.js. 
+
+Rollup will complain if `builtins` is present, and the build target is a browser. You may want [rollup-plugin-node-builtins](https://npm.im/package/rollup-plugin-node-builtins).
+

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 const path = require('path');
 const safeResolve = require('safe-resolve');
+const getBuiltins = require('builtins');
 const pkg = require(path.resolve('package.json'));
 
-module.exports = ({ dependencies, peerDependencies = true } = {}) => ({
+module.exports = ({ dependencies, builtins, peerDependencies = true } = {}) => ({
   name: 'auto-external',
   options(opts) {
     let external = [];
@@ -21,11 +22,15 @@ module.exports = ({ dependencies, peerDependencies = true } = {}) => ({
       ids = ids.concat(Object.keys(pkg.peerDependencies));
     }
 
+    if (builtins) {
+      ids = ids.concat(builtins === true ? getBuiltins() : getBuiltins(builtins));
+    }
+
     if (typeof opts.external === 'function') {
       external = id =>
         opts.external(id) || ids.map(safeResolve).filter(Boolean).includes(id);
     } else {
-      external = (opts.external || []).concat(ids);
+      external = Array.from(new Set((opts.external || []).concat(ids)));
     }
 
     return Object.assign({}, opts, { external });

--- a/index.test.js
+++ b/index.test.js
@@ -1,4 +1,5 @@
 const autoExternal = require('./index');
+const getBuiltins = require('builtins');
 
 jest.mock(
   './package.json',
@@ -82,6 +83,13 @@ describe('autoExternal(options)', () => {
     ]);
   });
 
+  it('should dedupe the array', () => {
+    expect(autoExternal().options({ external: ['module', 'depModule'] }).external)
+      .toEqual([
+        'module', 'depModule', 'peerModule'
+      ]);
+  });
+
   it('should handle extending external function', () => {
     const { external } = autoExternal().options({
       external: id => id.includes('module'),
@@ -98,5 +106,19 @@ describe('autoExternal(options)', () => {
     });
 
     expect(() => external('path/to/unknow')).not.toThrow();
+  });
+
+  it('should handle adding builtins', () => {
+    expect(autoExternal({ builtins: true }).options({}).external).toEqual([
+      'depModule',
+      'peerModule'
+    ].concat(getBuiltins()));
+  });
+
+  it('should handle adding builtins for a specific Node.js version', () => {
+    expect(autoExternal({ builtins: '6.0.0' }).options({}).external).toEqual([
+      'depModule',
+      'peerModule'
+    ].concat(getBuiltins('6.0.0')));
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -431,6 +431,14 @@
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
     },
+    "builtins": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-2.0.0.tgz",
+      "integrity": "sha512-8srrxpDx3a950BHYcbse+xMjupHHECvQYnShkoPz2ZLhTBrk/HQO6nWMh4o4ui8YYp2ourGVYXlGqFm+UYQwmA==",
+      "requires": {
+        "semver": "5.4.1"
+      }
+    },
     "callsites": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
@@ -2452,8 +2460,7 @@
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-      "dev": true
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "rollup": ">=0.45.2"
   },
   "dependencies": {
+    "builtins": "^2.0.0",
     "safe-resolve": "^1.0.0"
   }
 }


### PR DESCRIPTION
Thanks for this plugin.  When using Rollup to bundle Node.js libraries, it's helpful to declare builtin modules as externals.  I've added support to do this with a new `builtins` option.  Hope it's something you're interested in adding.

* * *

- add `builtins` option
- add [builtins](https://npm.im/builtins) dependency
- bonus: dedupes resulting array
- added tests
- added docs

Signed-off-by: Christopher Hiller <boneskull@boneskull.com>