### PR TITLE
feat: option to exclude dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ export default {
       dependencies: true,
       packagePath: path.resolve('./packages/module/package.json'),
       peerDependencies: false,
+      exclude: ['react']
     }),
   ],
 };
@@ -90,3 +91,7 @@ Rollup will complain if `builtins` is present, and the build target is a browser
 #### `peerDependencies`
 
 `boolean`: defaults to `true`.
+
+#### `exclude`
+
+`array`: defaults to `[]`. Array of dependencies to not mark as external.

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -346,6 +346,19 @@ export default index;
 "
 `;
 
+exports[`autoExternal(options) should handle excluded dependencies 1`] = `
+"import bar from 'bar';
+
+var foo = 'foo';
+
+var baz = 'baz';
+
+var index = \`\${foo}\${bar}\${baz}\`;
+
+export default index;
+"
+`;
+
 exports[`autoExternal(options) should handle extending external array 1`] = `
 "import foo from 'foo';
 import bar from 'bar';

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -116,4 +116,11 @@ describe('autoExternal(options)', () => {
     bundle({
       input: path.resolve(__dirname, '../__fixtures__/scoped/index.js'),
     }));
+
+  it('should handle excluded dependencies', () =>
+    bundle({
+      input: path.resolve(__dirname, '../__fixtures__/deps/index.js'),
+    }, {
+      exclude: ['foo']
+    }));
 });

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = ({
   dependencies = true,
   packagePath,
   peerDependencies = true,
+  exclude = []
 } = {}) => ({
   name: 'auto-external',
   options(opts) {
@@ -27,7 +28,12 @@ module.exports = ({
       ids = ids.concat(getBuiltins(semver.valid(builtins)));
     }
 
-    ids = ids.map(safeResolve).filter(Boolean);
+    exclude = exclude.map(safeResolve)
+
+    ids = ids
+          .map(safeResolve)
+          .filter(Boolean)
+          .filter(id => !exclude.includes(id));
 
     const external = id => {
       if (typeof opts.external === 'function' && opts.external(id)) {


### PR DESCRIPTION
Option to exclude certain dependencies from being automatically marked as external.

Perhaps this would be better as a `internal(['react'])` rollup plugin?

**EDIT:** I published this package: https://www.npmjs.com/package/rollup-plugin-internal