### PR TITLE
feat: Add options.bundledDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,7 @@ Rollup will complain if `builtins` is present, and the build target is a browser
 #### `peerDependencies`
 
 `boolean`: defaults to `true`.
+
+#### `bundledDependencies`
+
+`boolean`: defaults to `false`.

--- a/__fixtures__/bundled-deps/index.js
+++ b/__fixtures__/bundled-deps/index.js
@@ -1,0 +1,5 @@
+import foo from 'foo';
+import bar from 'bar';
+import baz from 'baz';
+
+export default `${foo}${bar}${baz}`;

--- a/__fixtures__/bundled-deps/package.json
+++ b/__fixtures__/bundled-deps/package.json
@@ -1,0 +1,6 @@
+{
+  "bundledDependencies": [
+    "foo",
+    "bar"
+  ]
+}

--- a/__tests__/__snapshots__/index.js.snap
+++ b/__tests__/__snapshots__/index.js.snap
@@ -346,6 +346,18 @@ export default index;
 "
 `;
 
+exports[`autoExternal(options) should handle enabling bundledDependencies 1`] = `
+"import foo from 'foo';
+import bar from 'bar';
+
+var baz = 'baz';
+
+var index = \`\${foo}\${bar}\${baz}\`;
+
+export default index;
+"
+`;
+
 exports[`autoExternal(options) should handle extending external array 1`] = `
 "import foo from 'foo';
 import bar from 'bar';
@@ -375,6 +387,21 @@ import bar from '@scope/bar';
 var baz = '@scope/baz';
 
 var index = \`\${foo}\${bar}\${baz}\`;
+
+export default index;
+"
+`;
+
+exports[`autoExternal(options) should not add bundledDependencies by default 1`] = `
+"var foo = 'foo';
+
+var bar = 'bar';
+
+var bar_1 = bar;
+
+var baz = 'baz';
+
+var index = \`\${foo}\${bar_1}\${baz}\`;
 
 export default index;
 "

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -55,6 +55,17 @@ describe('autoExternal(options)', () => {
       { input: path.resolve(__dirname, '../__fixtures__/peer-deps/index.js') },
       { peerDependencies: false }
     ));
+  
+  it('should not add bundledDependencies by default', () =>
+    bundle({
+      input: path.resolve(__dirname, '../__fixtures__/bundled-deps/index.js'),
+    }));
+  
+  it('should handle enabling bundledDependencies', () =>
+    bundle(
+      { input: path.resolve(__dirname, '../__fixtures__/bundled-deps/index.js') },
+      { bundledDependencies: true }
+    ));
 
   it('should add builtins by default', () =>
     bundle({

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = ({
   dependencies = true,
   packagePath,
   peerDependencies = true,
+  bundledDependencies = false,
 } = {}) => ({
   name: 'auto-external',
   options(opts) {
@@ -16,7 +17,17 @@ module.exports = ({
     let ids = [];
 
     if (dependencies && pkg.dependencies) {
-      ids = ids.concat(Object.keys(pkg.dependencies));
+      ids = ids.concat(
+        bundledDependencies
+        ? Object.keys(pkg.dependencies)
+        : Object.keys(pkg.dependencies).filter(id => {
+          return pkg.dependencies[id] !== '*'
+        })
+      );
+    } else if (bundledDependencies && pkg.dependencies) {
+      ids = ids.concat(Object.keys(pkg.dependencies).filter(id => {
+        return pkg.dependencies[id] === '*'
+      }));
     }
 
     if (peerDependencies && pkg.peerDependencies) {


### PR DESCRIPTION
Now `bundledDependencies` is treated as `dependencies` because of [`normalize-package-data#L102-L129`](https://github.com/npm/normalize-package-data/blob/9948ecf3d97cffcaab8f914522a0f3953edac6e4/lib/fixer.js#L102-L129). I'm not sure about its default value but isn't it likely that an option that can handle whether to include `bundledDependencies` might be useful?